### PR TITLE
chore: add a couple of entries to the `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/build
+.gdb_history


### PR DESCRIPTION
The `build` root directory is used by the laze configuration.