### PR TITLE
fix(cargo): update `include` value

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-include = "../build/imports/ariel-os/ariel-os-cargo.toml"
+include = ["../build/imports/ariel-os/ariel-os-cargo.toml"]
 
 [unstable]
 # This is needed so the "include" statement above works.


### PR DESCRIPTION
This accomodates the new unstable schema for the `inlude` directive in `.cargo/config.toml`. Similar to https://github.com/ariel-os/ariel-os/pull/1572.
Needed for the new CI workflow introduced by https://github.com/ariel-os/ariel-os/pull/1551 to succeed.